### PR TITLE
Gyro drive correction

### DIFF
--- a/BaseAuto.java
+++ b/BaseAuto.java
@@ -90,7 +90,7 @@ public abstract class BaseAuto extends LinearOpMode
 
     public final void travel(int encoderCounts, int originalEncoderCount, TravelDirection d) throws InterruptedException
     {
-        int origGyro = sensorGyro.getIntegratedZValue();
+        double origGyro = sensorGyro.getIntegratedZValue();
         if (d == TravelDirection.FORWARD)
         {
             while (((rightDriveMotor.getCurrentPosition() * -1) - originalEncoderCount) < encoderCounts)

--- a/BaseAuto.java
+++ b/BaseAuto.java
@@ -90,11 +90,13 @@ public abstract class BaseAuto extends LinearOpMode
 
     public final void travel(int encoderCounts, int originalEncoderCount, TravelDirection d) throws InterruptedException
     {
+        int origGyro = sensorGyro.getIntegratedZValue();
         if (d == TravelDirection.FORWARD)
         {
             while (((rightDriveMotor.getCurrentPosition() * -1) - originalEncoderCount) < encoderCounts)
             {
-                rightDriveMotor.setPower(1.0);
+                rightDriveMotor.setPower(1.0 - (((sensorGyro.getIntegratedZValue() + 180) - (origGyro + 180))
+                        /360));
                 leftDriveMotor.setPower(1.0);
                 telemetry.addData("encoder position", -1 * rightDriveMotor.getCurrentPosition());
                 waitOneFullHardwareCycle();

--- a/BaseAuto.java
+++ b/BaseAuto.java
@@ -90,15 +90,14 @@ public abstract class BaseAuto extends LinearOpMode
 
     public final void travel(int encoderCounts, int originalEncoderCount, TravelDirection d) throws InterruptedException
     {
-        double origGyro = sensorGyro.getIntegratedZValue();
+        double origGyro = sensorGyro.getHeading();
         if (d == TravelDirection.FORWARD)
         {
-            while (((rightDriveMotor.getCurrentPosition() * -1) - originalEncoderCount) < encoderCounts)
+            while (((leftDriveMotor.getCurrentPosition() * -1) - originalEncoderCount) < encoderCounts)
             {
-                rightDriveMotor.setPower(1.0 - (((sensorGyro.getIntegratedZValue() + 180) - (origGyro + 180))
-                        /360));
+                rightDriveMotor.setPower(1.0 - (((sensorGyro.getHeading() + 180) - (origGyro + 180)) /360));
                 leftDriveMotor.setPower(1.0);
-                telemetry.addData("encoder position", -1 * rightDriveMotor.getCurrentPosition());
+                telemetry.addData("encoder position", -1 * leftDriveMotor.getCurrentPosition());
                 waitOneFullHardwareCycle();
             }
             telemetry.clearData();
@@ -107,11 +106,11 @@ public abstract class BaseAuto extends LinearOpMode
         }
         else
         {
-            while (((rightDriveMotor.getCurrentPosition() * -1) - originalEncoderCount) > encoderCounts)
+            while (((leftDriveMotor.getCurrentPosition() * -1 - originalEncoderCount) > encoderCounts))
             {
                 rightDriveMotor.setPower(-1.0);
                 leftDriveMotor.setPower(-1.0);
-                telemetry.addData("encoder position", -1 * rightDriveMotor.getCurrentPosition());
+                telemetry.addData("encoder position", -1 * leftDriveMotor.getCurrentPosition());
                 waitOneFullHardwareCycle();
             }
             telemetry.clearData();
@@ -125,26 +124,20 @@ public abstract class BaseAuto extends LinearOpMode
 
     public final void rotate(int turnAngle, int originalTotalRotation, TurnDirection d) throws InterruptedException
     {
-        if (d == TurnDirection.CLOCKWISE)
-        {
-            while (sensorGyro.getIntegratedZValue() < (originalTotalRotation + turnAngle))
+
+            while (Math.abs(sensorGyro.getIntegratedZValue()) < Math.abs(originalTotalRotation) + turnAngle)
             {
-                rightDriveMotor.setPower(-0.4675);
-                leftDriveMotor.setPower(0.1);
+                if (d == TurnDirection.CLOCKWISE) {
+                    rightDriveMotor.setPower(-0.4675);
+                    leftDriveMotor.setPower(1.0);
+                }
+                else {
+                    rightDriveMotor.setPower(0.4675);
+                    leftDriveMotor.setPower(-1.0);
+                }
                 telemetry.addData("Gyro Position", sensorGyro.getIntegratedZValue());
                 waitOneFullHardwareCycle();
             }
-        }
-        else
-        {
-            while (sensorGyro.getIntegratedZValue() > (originalTotalRotation - turnAngle))
-            {
-                rightDriveMotor.setPower(0.4675);
-                leftDriveMotor.setPower(-1.0);
-                telemetry.addData("Gyro Position", sensorGyro.getIntegratedZValue());
-                waitOneFullHardwareCycle();
-            }
-        }
         rightDriveMotor.setPower(0.0);
         leftDriveMotor.setPower(0.0);
     }

--- a/RedRampAuto.java
+++ b/RedRampAuto.java
@@ -33,6 +33,10 @@ public class RedRampAuto extends BaseAuto {
     {
         if (step == 1) {
             travel(8275, 0, TravelDirection.FORWARD);
+            rightDriveMotor.setPower(0);
+            leftDriveMotor.setPower(0);
+            Thread.sleep(1000);
+            waitOneFullHardwareCycle();
             recursiveAuto(2);
         }
         if (step == 2) {

--- a/RedRampAuto.java
+++ b/RedRampAuto.java
@@ -20,9 +20,6 @@ import com.qualcomm.robotcore.hardware.DcMotorController;
 public class RedRampAuto extends BaseAuto {
 
 
-
-
-
     @Override
     public void runOpMode() throws InterruptedException {
         super.runOpMode();
@@ -34,14 +31,24 @@ public class RedRampAuto extends BaseAuto {
 
     public void recursiveAuto(int step) throws InterruptedException // 9000 encoder clicks equals 86"
     {
-        if (step == 1)
-        {
-            travel(8275, rightDriveMotor.getCurrentPosition(), TravelDirection.FORWARD);
+        if (step == 1) {
+            travel(8275, 0, TravelDirection.FORWARD);
             recursiveAuto(2);
         }
-        if (step == 2)
-        {
+        if (step == 2) {
             rotate(45, sensorGyro.getIntegratedZValue(), TurnDirection.COUNTER_CLOCKWISE);
+        }
+        if (step == 3)
+        {
+            travel(1000, leftDriveMotor.getCurrentPosition(), TravelDirection.FORWARD);
+            //travel up to the climber bucket
+        }
+        if(step == 4)
+        {
+            //
+            leftScissorsMotor.setPower(0.5);
+            rightScissorsMotor.setPower(0.5);
+            //
         }
     }
 }


### PR DESCRIPTION
To fix left drift: now we scale right motor power based on gyro angle. 

The higher the differentiation from straight, the less power is delivered to the right drive motor. 

Now we drive straight when using the travel() method.